### PR TITLE
Added hide for video views

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -242,6 +242,17 @@
         </label>
       </div>
       <div class="checkbox-container">
+        <label for="video-views">Hide Views Count</label>
+        <label class="switch">
+          <input
+            type="checkbox"
+            id="video-views"
+            name="video-views"
+          />
+          <span class="slider round"></span>
+        </label>
+      </div>
+      <div class="checkbox-container">
         <label for="video-likes-dislikes">Hide Video Likes/Dislikes</label>
         <label class="switch">
           <input

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -221,6 +221,13 @@ const DEFAULT_ELEMENTS = [
     pageTypes: [PAGE_TYPES.VIDEO],
   },
   {
+    id: "video-views",
+    selector: "(//div[@id='description']//div[@id='info-container']//yt-formatted-string[@id='info']//span)[1]",
+    checked: false,
+    category: "Video",
+    pageTypes: [PAGE_TYPES.VIDEO],
+  },
+  {
     id: "video-likes-dislikes",
     selector: "//segmented-like-dislike-button-view-model",
     checked: false,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dd70197f-3a86-412a-82d5-bc50834f2a3d)

As shown above, its working as intended.
However, if the goal is to prevent bias when choosing which content to watch
It should hide the view count for all recommended videos like these:

![image](https://github.com/user-attachments/assets/842f1818-63b6-4330-9916-4ffd325aa7ca)

We could add another input for this, but i think we need to upgrade the structure to pass an array of selectors instead of just a single selector 🤔

Something like this:

```js
{
    id: "video-views",
    selectors: [
        "(//div[@id='description']//div[@id='info-container']//yt-formatted-string[@id='info']//span)[1]",
        "(//ytd-compact-video-renderer//div[contains(@class, 'details')]//ytd-video-meta-block//div[@id='metadata-line']//span[contains(@class, 'inline-metadata-item')])[1]"
    ],
    checked: false,
    category: "Video",
    pageTypes: [PAGE_TYPES.VIDEO],
}
  ```
