### PR TITLE
Feature : Auto expand chapters

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -400,7 +400,7 @@
         </label>
       </div>
       <div class="checkbox-container">
-        <label for="checkbox-container">Auto Expand Video Chapters</label>
+        <label for="expand-video-chapters">Auto Expand Video Chapters</label>
         <label class="switch">
           <input
             type="checkbox"

--- a/public/popup.html
+++ b/public/popup.html
@@ -399,6 +399,17 @@
           <span class="slider round"></span>
         </label>
       </div>
+      <div class="checkbox-container">
+        <label for="checkbox-container">Auto Expand Video Chapters</label>
+        <label class="switch">
+          <input
+            type="checkbox"
+            id="expand-video-chapters"
+            name="expand-video-chapters"
+          />
+          <span class="slider round"></span>
+        </label>
+      </div>
     </div>
 
     <button class="collapsible">Stream</button>

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -335,6 +335,13 @@ const DEFAULT_ELEMENTS = [
     pageTypes: [PAGE_TYPES.VIDEO],
   },
   {
+    id: "expand-video-chapters",
+    selector: "//div[contains(@class, 'ytp-chapter-container')]",
+    checked: false,
+    category: "Video",
+    pageTypes: [PAGE_TYPES.VIDEO],
+  },
+  {
     id: "stream-chat",
     selector: "//div[@id='chat-container']",
     checked: false,
@@ -401,8 +408,12 @@ function debounce(func, wait) {
 
 class YouTubeElement {
   constructor(config) {
+    const clickActionElementsIds = [
+      "expand-video-description",
+      "expand-video-chapters",
+    ];
     Object.assign(this, config);
-    this.isClickAction = config.id === "expand-video-description";
+    this.isClickAction = clickActionElementsIds.includes(config.id);
   }
 
   async toggle(hide) {

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -424,6 +424,9 @@ class YouTubeElement {
   }
 
   async handleClick(click) {
+    const expandedStorage = await chrome.storage.local.get();
+    if (expandedStorage[`${this.id}-expanded`]) return;
+
     if (click) {
       const elementToClick = document.evaluate(
         this.selector,
@@ -432,7 +435,12 @@ class YouTubeElement {
         XPathResult.FIRST_ORDERED_NODE_TYPE,
         null
       ).singleNodeValue;
-      elementToClick?.click();
+
+      if (elementToClick) {
+        const prop = `${this.id}-expanded`;
+        await chrome.storage.local.set({ [prop]: true });
+        elementToClick.click();
+      }
     }
   }
 
@@ -565,8 +573,13 @@ class TubeMod {
     this.elementManager.setupObserver();
   }
 
-  handleYouTubeNavigate() {
+  async handleYouTubeNavigate() {
     this.elementManager.applyAllElements(getCurrentPageType());
+    for (const key in await chrome.storage.local.get()) {
+      if (key.includes("-expanded")) {
+        await chrome.storage.local.remove(key);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Close : https://github.com/Pedro-Gregorio/TubeMod/issues/18
I make a new PR as I made a mess with the old one ^^

Automatically expand chapters if available
And fixed an issue with auto expand, I can't think of any other way to do this, but in order to prevent elements from being clicked on indefinitely once certain components have been refresh (e.g. the video player), I keep track of which components have already been extended for the current page.