### PR TITLE
Change: remove "tabs" permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     "48": "/icons/icon_48.png",
     "128": "/icons/icon_128.png"
   },
-  "permissions": ["tabs", "activeTab", "storage"],
+  "permissions": ["activeTab", "storage"],
   "background": {
     "service_worker": "./scripts/background.js"
   },

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -12,7 +12,7 @@
     "48": "/icons/icon_48.png",
     "128": "/icons/icon_128.png"
   },
-  "permissions": ["tabs", "activeTab", "storage"],
+  "permissions": ["activeTab", "storage"],
   "background": {
     "scripts": ["./scripts/background.js"]
   },


### PR DESCRIPTION
I've used this modified manifests (on Firefox and Edge) since yesterday and everything works exactly the same, even after a browser restart.

Closes #26.