### PR TITLE
Adds option to hide amount of likes in the video

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -267,6 +267,17 @@
         </label>
       </div>
       <div class="checkbox-container">
+        <label for="video-likes-amount">Hide Video Likes Amount</label>
+        <label class="switch">
+          <input
+            type="checkbox"
+            id="video-likes-amount"
+            name="video-likes-amount"
+          />
+          <span class="slider round"></span>
+        </label>
+      </div>
+      <div class="checkbox-container">
         <label for="video-likes-dislikes">Hide Video Likes/Dislikes</label>
         <label class="switch">
           <input

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -243,6 +243,13 @@ const DEFAULT_ELEMENTS = [
     pageTypes: [PAGE_TYPES.VIDEO],
   },
   {
+    id: "video-likes-amount",
+    selector: "//*[@id='top-level-buttons-computed']/segmented-like-dislike-button-view-model/yt-smartimation/div/div/like-button-view-model/toggle-button-view-model/button-view-model/button/div[2]",
+    checked: false,
+    category: "Video",
+    pageTypes: [PAGE_TYPES.VIDEO],
+  },
+  {
     id: "video-likes-dislikes",
     selector: "//segmented-like-dislike-button-view-model",
     checked: false,


### PR DESCRIPTION
It is a bit awkward for the moment because of one the parents has a margin that makes it not be centered enough when there is no number.

It could be fixed if the extension allowed for a way to modify the CSS, but for the moment this is all that can be done.