### PR TITLE
Hide new video badge homepage - v1.6

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -233,7 +233,7 @@
         </label>
       </div>
       <div class="checkbox-container">
-        <label for="posts">Hide "New" badge</label>
+        <label for="new-badge">Hide "New" badge</label>
         <label class="switch">
           <input type="checkbox" id="new-badge" name="new-badge" />
           <span class="slider round"></span>

--- a/public/popup.html
+++ b/public/popup.html
@@ -232,6 +232,13 @@
           <span class="slider round"></span>
         </label>
       </div>
+      <div class="checkbox-container">
+        <label for="posts">Hide "New" badge</label>
+        <label class="switch">
+          <input type="checkbox" id="new-badge" name="new-badge" />
+          <span class="slider round"></span>
+        </label>
+      </div>
     </div>
 
     <button class="collapsible">Subscriptions</button>

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -230,6 +230,13 @@ const DEFAULT_ELEMENTS = [
     pageTypes: [PAGE_TYPES.HOME],
   },
   {
+    id: "new-badge",
+    selector: "//yt-thumbnail-overlay-badge-view-model",
+    checked: false,
+    category: "HomePage",
+    pageTypes: [PAGE_TYPES.HOME],
+  },
+  {
     id: "subscriptions-shorts",
     selector: "//ytd-rich-shelf-renderer/../.. | //ytd-rich-shelf-renderer",
     checked: false,


### PR DESCRIPTION
Hides the "new" badges from new videos. 

The same as #38 but rebased to v1.6