### PR TITLE
Hide time posted homepage - v1.6

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -232,6 +232,13 @@
           <span class="slider round"></span>
         </label>
       </div>
+      <div class="checkbox-container">
+        <label for="posts">Hide Time Posted in HomePage</label>
+        <label class="switch">
+          <input type="checkbox" id="time-posted" name="time-posted" />
+          <span class="slider round"></span>
+        </label>
+      </div>
     </div>
 
     <button class="collapsible">Subscriptions</button>

--- a/public/popup.html
+++ b/public/popup.html
@@ -233,7 +233,7 @@
         </label>
       </div>
       <div class="checkbox-container">
-        <label for="posts">Hide Time Posted in HomePage</label>
+        <label for="time-posted">Hide Time Posted in HomePage</label>
         <label class="switch">
           <input type="checkbox" id="time-posted" name="time-posted" />
           <span class="slider round"></span>

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -230,6 +230,13 @@ const DEFAULT_ELEMENTS = [
     pageTypes: [PAGE_TYPES.HOME],
   },
   {
+    id: "time-posted",
+    selector: "//div[@id='metadata-line']/span[2]",
+    checked: false,
+    category: "HomePage",
+    pageTypes: [PAGE_TYPES.HOME],
+  },
+  {
     id: "subscriptions-shorts",
     selector: "//ytd-rich-shelf-renderer/../.. | //ytd-rich-shelf-renderer",
     checked: false,


### PR DESCRIPTION
Hides the time since the video was posted in the homepage. Not much.

Same as #37 but rebased to v1.6