### PR TITLE
Feat: Remove Elements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,9 @@
       "js": ["./scripts/content.js"],
       "run_at": "document_start"
     }
+  ],
+  "host_permissions": [
+  "*://www.youtube.com/*",
+  "*://m.youtube.com/*"
   ]
 }

--- a/public/popup.css
+++ b/public/popup.css
@@ -71,6 +71,16 @@ label {
   padding: 2px 4px;
 }
 
+.non-categorized {
+  padding: 0px;
+  margin-bottom: 10px;
+}
+
+.non-categorized label:not(.switch) {
+  text-align: center;
+  flex: 1;
+}
+
 .checkbox-container label {
   font-size: 14px;
   font-weight: bold;

--- a/public/popup.html
+++ b/public/popup.html
@@ -10,6 +10,15 @@
       <h3>Make YouTube your own!</h3>
     </div>
 
+    <div class="checkbox-container non-categorized">
+      <label for="hide-delete-toggle">Hide Elements</label>
+      <label class="switch">
+        <input type="checkbox" id="hide-delete-toggle" name="hide-delete-toggle" />
+        <span class="slider round"></span>
+      </label>
+      <label for="hide-delete-toggle">Delete Elements</label>
+    </div>
+
     <button class="collapsible">General</button>
     <div class="container" id="general" style="display: none">
       <div class="checkbox-container">

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -23,6 +23,13 @@ function getCurrentPageType() {
 
 const DEFAULT_ELEMENTS = [
   {
+    id: "hide-delete-toggle",
+    selector: "hide-delete-toggle",
+    checked: false,
+    category: "Behaviours",
+    pageTypes: [],
+  },
+  {
     id: "logo",
     selector: "//ytd-topbar-logo-renderer",
     checked: false,
@@ -353,6 +360,18 @@ const DEFAULT_ELEMENTS = [
   },
 ];
 
+let removeElements = false;
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.action === "set-hide-elements") {
+    removeElements = false;
+    console.log("Hide elements mode activated.");
+  } else if (message.action === "set-delete-elements") {
+    removeElements = true;
+    console.log("Delete elements mode activated.");
+  }
+});
+
 const eventBus = {
   listeners: {},
   subscribe(event, callback) {
@@ -441,7 +460,12 @@ class YouTubeElement {
     );
 
     for (let i = 0; i < elements.snapshotLength; i++) {
-      elements.snapshotItem(i).style.display = displayValue;
+      if (removeElements && (displayValue === "none")) {
+        elements.snapshotItem(i).remove();
+      }
+      else {
+        elements.snapshotItem(i).style.display = displayValue;
+      }
     }
 
     if (this.selector === "//div[@id='chat-container']") {
@@ -449,7 +473,12 @@ class YouTubeElement {
         "panels-full-bleed-container"
       );
       if (panelsContainer) {
-        panelsContainer.style.display = displayValue;
+        if (removeElements && (displayValue === "none")) {
+          panelsContainer.style.display = displayValue;
+        }
+        else {
+          panelsContainer.remove();
+        }
       }
     }
   }

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,6 +1,8 @@
 let inputs = document.querySelectorAll("input");
 let collapsibleElements = document.getElementsByClassName("collapsible");
 
+let removeElements = false;
+
 document.addEventListener("DOMContentLoaded", () => {
   chrome.storage.local.get(["elements"], (result) => {
     const elements = result.elements ? JSON.parse(result.elements) : null;
@@ -11,9 +13,19 @@ document.addEventListener("DOMContentLoaded", () => {
           document.getElementById(element.id).checked = element.checked;
         }
       });
+
+      const hideDeleteToggle = elements.find(el => el.id === "hide-delete-toggle");
+      console.log(hideDeleteToggle);
+      if (hideDeleteToggle && hideDeleteToggle.checked) {
+        removeElements = true;
+        console.log("RemoveElements is true");
+      } else {
+        removeElements = false;
+        console.log("RemoveElements is false");
+      }
     }
 
-    for (i = 0; i < collapsibleElements.length; i++) {
+    for (let i = 0; i < collapsibleElements.length; i++) {
       collapsibleElements[i].addEventListener("click", function () {
         this.classList.toggle("active");
         var content = this.nextElementSibling;
@@ -60,4 +72,22 @@ document.getElementById("reset-settings").addEventListener("click", () => {
     });
   });
   window.close();
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  const hideDeleteToggle = document.getElementById("hide-delete-toggle");
+
+  hideDeleteToggle.addEventListener("change", () => {
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+      if (hideDeleteToggle.checked) {
+        chrome.tabs.sendMessage(tabs[0].id, {
+          action: "set-delete-elements",
+        });
+      } else {
+        chrome.tabs.sendMessage(tabs[0].id, {
+          action: "set-hide-elements",
+        });
+      }
+    });
+  });
 });


### PR DESCRIPTION
Finally done!

Adds the ability to toggle between removing the elements from the DOM or hiding them with CSS (already implemented). It is configured by a toggle that appears in first position in the UI.

In my testing in works fine, however it doesn't completely delete the elements before they are loaded, and it seems to be a bit delayed. Maybe that could be fixed in later iterations, but for now, I can't seem to find a way to achieve it.

Also, I suck at writing JS so it might have some issues. I however, didn't find any.