### PR TITLE
[Fix] Toggle switch no longer shrinks with longer labels

### DIFF
--- a/documentation/ReleaseNotes.md
+++ b/documentation/ReleaseNotes.md
@@ -2,6 +2,9 @@
 
 ## 1.7.0
 
+Fix: 
+
+- Toggles now mantain their width regardless of label length 
 
 
 ## 1.6.0 

--- a/public/popup.css
+++ b/public/popup.css
@@ -84,7 +84,7 @@ label {
 .switch {
   position: relative;
   display: inline-block;
-  width: 50px;
+  min-width: 50px;
   height: 30px;
   outline: none;
 }


### PR DESCRIPTION
It is just a fix to #73. Really minute change.

Just changes the width of the slider to be the minimum width possible. 

`width: 50px` -> `min-width: 50px`

Also, this time I read the README and updated also the Release Notes.