### PR TITLE
Add: Hide Offer Module on Video page

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -597,6 +597,13 @@
         </label>
       </div>
       <div class="checkbox-container">
+        <label for="video-offer-module">Hide Offer Module</label>
+        <label class="switch">
+          <input type="checkbox" id="video-offer-module" name="video-offer-module" />
+          <span class="slider round"></span>
+        </label>
+      </div>
+      <div class="checkbox-container">
         <label for="video-tabs">Hide Suggested Videos Tabs</label>
         <label class="switch">
           <input type="checkbox" id="video-tabs" name="video-tabs" />

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -59,7 +59,7 @@ function getCurrentPageType() {
 }
 
 const STORAGE = {
-  tubemod_version: "1.9.0G",
+  tubemod_version: "1.9.1G",
   tubemod_elements: [
     {
       id: "scheduled-videos",
@@ -589,6 +589,14 @@ const STORAGE = {
       pageTypes: [PAGE_TYPES.VIDEO],
     },
     {
+      id: "video-offer-module",
+      selector: "//div[@id='offer-module']",
+      checked: false,
+      property: DISPLAY,
+      style: DISPLAY_NONE,
+      pageTypes: [PAGE_TYPES.VIDEO],
+    },
+    {
       id: "video-tabs",
       selector: "//yt-related-chip-cloud-renderer",
       checked: false,
@@ -709,7 +717,7 @@ class YouTubeElement {
       XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,
       null
     );
-
+    
     for (let i = 0; i < elements.snapshotLength; i++) {
       hide
         ? (elements.snapshotItem(i).style[this.property] = this.style)


### PR DESCRIPTION
Adds a slider to hide the offer module from the video page. This is the module that pops up in the top right of the video page when you can buy or rent a show or movie from YouTube.

Before:
![image](https://github.com/user-attachments/assets/3f070389-e96c-4b62-8977-63c8642133e9)

Slider:
![image](https://github.com/user-attachments/assets/ed0ecd31-3f9f-44eb-813b-a898aca1df10)


After:
![image](https://github.com/user-attachments/assets/0f4e4cbe-f0fc-4041-a971-b0a0d61fb972)

