### PR TITLE
Add: Remove Downloaded Badge

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -74,6 +74,13 @@
           <span class="slider round"></span>
         </label>
       </div>
+      <div class="checkbox-container">
+        <label for="download-badge">Hide Downloaded badge in Downloads</label>
+        <label class="switch">
+          <input type="checkbox" id="download-badge" name="download-badge" />
+          <span class="slider round"></span>
+        </label>
+      </div>
     </div>
 
     <button class="collapsible">Header</button>

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -12,6 +12,7 @@ const PAGE_TYPES = {
   VIDEO: "video",
   SEARCH: "search",
   TRENDING: "trending",
+  DOWNLOADS: "downloads"
 };
 
 function saveSettings() {
@@ -58,6 +59,8 @@ function getCurrentPageType() {
     return PAGE_TYPES.SEARCH;
   } else if (url.includes("/feed/trending")) {
     return PAGE_TYPES.TRENDING;
+  } else if (url.includes("/feed/downloads")) {
+    return PAGE_TYPES.DOWNLOADS;
   }
   return null;
 }
@@ -122,6 +125,14 @@ const STORAGE = {
       checked: false,
       property: TEXT_TRANSFORM,
       style: LOWERCASE,
+      pageTypes: [],
+    },
+    {
+      id: "download-badge",
+      selector: "//p[text()[contains(., 'Downloaded')]]",
+      checked: false,
+      property: DISPLAY,
+      style: DISPLAY_NONE,
       pageTypes: [],
     },
     {


### PR DESCRIPTION
On the Downloads page, the user can remove the 'Downloaded' Badge as this is repetitive on the page.

After removing badge:
![Screenshot 2025-01-16 205012](https://github.com/user-attachments/assets/ed3d5aa3-5d31-45d3-99f0-daf3b914bbbb)

