### PR TITLE
Add: Hide Downloaded badge

### DIFF
--- a/documentation/ReleaseNotes.md
+++ b/documentation/ReleaseNotes.md
@@ -1,5 +1,12 @@
 # TubeMod - Release Notes
 
+## 1.14.0
+
+Add:
+
+- Downloads:
+  - Hide 'Downloaded' badge beneath downloaded videos
+
 ## 1.13.0
 
 Add:

--- a/public/popup.html
+++ b/public/popup.html
@@ -74,6 +74,13 @@
           <span class="slider round"></span>
         </label>
       </div>
+      <div class="checkbox-container">
+        <label for="download-badge">Hide Downloaded badge in Downloads</label>
+        <label class="switch">
+          <input type="checkbox" id="download-badge" name="download-badge" />
+          <span class="slider round"></span>
+        </label>
+      </div>
     </div>
 
     <button class="collapsible">Header</button>

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -12,6 +12,7 @@ const PAGE_TYPES = {
   VIDEO: "video",
   SEARCH: "search",
   TRENDING: "trending",
+  DOWNLOADS: "downloads"
 };
 
 function saveSettings() {
@@ -58,6 +59,8 @@ function getCurrentPageType() {
     return PAGE_TYPES.SEARCH;
   } else if (url.includes("/feed/trending")) {
     return PAGE_TYPES.TRENDING;
+  } else if (url.includes("/feed/downloads")) {
+    return PAGE_TYPES.DOWNLOADS;
   }
   return null;
 }
@@ -123,6 +126,14 @@ const STORAGE = {
       property: TEXT_TRANSFORM,
       style: LOWERCASE,
       pageTypes: [],
+    },
+    {
+      id: "download-badge",
+      selector: "//p[text()[contains(., 'Downloaded')]]",
+      checked: false,
+      property: DISPLAY,
+      style: DISPLAY_NONE,
+      pageTypes: [PAGE_TYPES.DOWNLOADS],
     },
     {
       id: "logo",


### PR DESCRIPTION
Continuation of #128 
On the Downloads page, the user can remove the 'Downloaded' Badge as this is repetitive on the page.
