### PR TITLE
Fix: Hide "New" badge in suggested videos

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -816,7 +816,7 @@ const STORAGE = {
     {
       id: "video-suggested-videos-new-badge",
       selector:
-        "//ytd-compact-video-renderer//div/ytd-badge-supported-renderer[.//div[contains(@class, 'badge')]]",
+        "//div[@id='secondary']//yt-content-metadata-view-model//div[.//yt-badge-view-model[.//div[text()='New']]]",
       checked: false,
       property: DISPLAY,
       style: DISPLAY_NONE,


### PR DESCRIPTION
Fixes #149 

This is based on the hierarchy I see on my browser, so might need extra testing.

Let me know if there are any sugestions.